### PR TITLE
Add support for FreeBSD during tests so that installation succeeds.

### DIFF
--- a/t/02-cannon-name.t
+++ b/t/02-cannon-name.t
@@ -6,7 +6,7 @@ use NativeLibs:ver<0.0.7>;
 my &cn = &NativeLibs::cannon-name;
 
 given $*VM.config<osname> {
-    when 'linux' {
+    when 'linux'|'freebsd' {
         is cn('foo'),          'libfoo.so',    'libfoo.so';
         is cn('libfoo.so'),    'libfoo.so',    'the same';
 


### PR DESCRIPTION
Compares $*VM.config<osname> with linux and freebsd using a junction so that the test passes to successfully install on FreeBSD.